### PR TITLE
fix: implementing `__len__` made the bool-value not what one would ex…

### DIFF
--- a/tests/test_url.py
+++ b/tests/test_url.py
@@ -152,3 +152,8 @@ def test_url_dict_access_query_values():
     assert url.query == {'a': '1'}
 
 
+def test_url_bool_value():
+    assert not Url()
+    assert Url('a')
+    assert Url(query={'day': 'today'})
+    assert Url(host='example.com')

--- a/xurls/url.py
+++ b/xurls/url.py
@@ -1186,6 +1186,10 @@ class Url:
     def __delitem__(self, key):
         self.query_remove(key)
 
+    def __bool__(self):
+        # Check to see if `url` is empty in terms of any url string it would generate.
+        return bool(str(self))
+
     # ---------------------------
     # --------- Private ---------
 


### PR DESCRIPTION
…pect.

It's possible to have a path without query-values, and users would expect that to be True still.

Using the formatted string representation of url, if it's not a blank string return True, otherwise if it's a blank string return False.